### PR TITLE
Feat: Add retry/shallow flags and print page that contains a broken link

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -1,23 +1,26 @@
 #!/usr/bin/env node
-const program = require('commander')
-const chalk = require('chalk')
-const package = require('../package')
-const poke = require('../lib')
+const program = require('commander');
+const chalk = require('chalk');
+const package = require('../package');
+const poke = require('../lib');
 
-let givenUrl = ''
+let givenUrl = '';
 
-program 
+program
   .version(package.version)
   .arguments('<url>')
-  .action((url) => {
-    givenUrl = url
-  })
+  .option('-r, --retry [value]', 'Broken links are retried with new hostname')
+  .action(url => {
+    givenUrl = url;
+  });
 
-program.parse(process.argv)
+program.parse(process.argv);
 
 if (!givenUrl) {
-  console.error(chalk.red('Error: No URL Given'))
-  process.exit(1)
-} 
+  console.error(chalk.red('Error: No URL Given'));
+  process.exit(1);
+}
 
-poke(givenUrl)
+poke(givenUrl, {
+  retry: program.retry,
+});

--- a/bin/app.js
+++ b/bin/app.js
@@ -10,6 +10,7 @@ program
   .version(package.version)
   .arguments('<url>')
   .option('-r, --retry [value]', 'Broken links are retried with new hostname')
+  .option('-s, --shallow', 'Do not check pages rooted outside of provided url')
   .action(url => {
     givenUrl = url;
   });
@@ -23,4 +24,5 @@ if (!givenUrl) {
 
 poke(givenUrl, {
   retry: program.retry,
+  shallow: program.shallow,
 });

--- a/lib/image-size.js
+++ b/lib/image-size.js
@@ -2,17 +2,18 @@ const remote = require('remote-file-size');
 const ora = require('ora');
 const cliTruncate = require('cli-truncate');
 
-
 module.exports = (images, callback) => {
   const spinner = ora('Checking The Size Of Images...').start();
-  spinner.start()
 
   const largeImages = [];
 
   let i = 0;
   function go() {
     if (i < images.length) {
-      spinner.text = spinner.text = cliTruncate('Checking ' + images[i], process.stdout.columns - 3);
+      spinner.text = spinner.text = cliTruncate(
+        'Checking ' + images[i],
+        process.stdout.columns - 3,
+      );
       testImage(images[i], (size, url) => {
         if (size / 1000 > 500) largeImages.push(url);
 
@@ -20,7 +21,7 @@ module.exports = (images, callback) => {
         go();
       });
     } else {
-      spinner.stop()
+      spinner.stop();
       callback(largeImages);
     }
   }
@@ -31,7 +32,12 @@ module.exports = (images, callback) => {
 // Returns { result: bool, url }
 function testImage(url, callback) {
   remote(url, (err, size) => {
-    if (err) console.log(err);
+    if (err) {
+      //skip a line for spinner
+      console.log(`
+failed to fetch ${url}`);
+      console.log(err);
+    }
 
     callback(size, url);
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,45 +3,51 @@ const imageSize = require('./image-size');
 const chalk = require('chalk');
 const url = require('url');
 
-function poke(site) {
+function poke(site, options) {
   // Check for broken links, media, iframes,
   // stylesheets, scripts, forms, metadata
-  missingContent(site, (brokenLinks, workingLinks) => {
+  missingContent(site, options, (brokenLinks, workingLinks) => {
     const imageExtensions = ['jpeg', 'jpg', 'png', 'gif', 'bmp'];
     const images = workingLinks.filter(link =>
-      strIncludes(url.parse(link, true).pathname, imageExtensions)
+      strIncludes(url.parse(link, true).pathname, imageExtensions),
     );
 
     imageSize(images, largeImages => {
-      report(brokenLinks, largeImages);
+      report(site, brokenLinks, largeImages);
     });
   });
 }
 
-function report(brokenLinks, largeImages) {
-  let error = false
+function report(site, brokenLinks, largeImages) {
+  let error = false;
 
-  if (brokenLinks.length === 0) {
+  while (site.endsWith('/')) {
+    site = site.slice(0, -1);
+  }
+
+  if (brokenLinks.size === 0) {
     console.log(chalk.green('No Missing / Broken Content Found :)'));
   } else {
-    error = true
+    error = true;
     console.log(chalk.red('Missing / Broken Content Found :('));
-    brokenLinks.forEach(link => console.log(' - ' + link));
+    brokenLinks.forEach((origin, broken) =>
+      console.log(origin + ' - ' + broken),
+    );
   }
 
   if (largeImages.length === 0) {
     console.log(chalk.green('\nNo Images Over 500kb :)'));
   } else {
-    error = true
+    error = true;
     console.log(chalk.red('\nImages Over 500kb found :('));
     largeImages.forEach(link => console.log(' - ' + link));
   }
 
-  error ? process.exit(1) : process.exit(0)
+  error ? process.exit(1) : process.exit(0);
 }
 
 function ensureString(str) {
-  return str || "";
+  return str || '';
 }
 
 function strIncludes(str, includes) {

--- a/lib/missing-content.js
+++ b/lib/missing-content.js
@@ -2,39 +2,82 @@ const blc = require('broken-link-checker');
 const ora = require('ora');
 const cliTruncate = require('cli-truncate');
 
-module.exports = (url, callback) => {
+module.exports = (url, options, callback) => {
   const spinner = ora('Checking For Missing Content').start();
-  const brokenLinks = [];
+  const brokenLinks = new Map();
   const links = [];
 
   // Options for broken-link-checker
   const blcOptions = {
     filterLevel: 3,
     honorRobotExclusions: false,
-    excludedSchemes: ['data', 'geo', 'javascript', 'mailto', 'sms', 'tel', '#']
+    excludedSchemes: ['data', 'geo', 'javascript', 'mailto', 'sms', 'tel', '#'],
   };
+
+  let htmlChecker;
+  let currentPage;
+  let redirectedHome;
+  const urlChecker = new blc.UrlChecker(options, {
+    link: function(result, customData) {
+      const checkedUrl = result.url.resolved;
+      spinner.text = cliTruncate(
+        'Checking ' + checkedUrl,
+        process.stdout.columns - 3,
+      );
+      if (
+        result.broken &&
+        result.brokenReason === 'HTTP_404' &&
+        !brokenLinks.has(checkedUrl)
+      ) {
+        brokenLinks.set(checkedUrl, currentPage);
+      }
+    },
+    end: () => {
+      siteChecker.resume();
+    },
+  });
 
   // handlers
   const handlers = {
+    html: (tree, robots, response, pageUrl, customData) => {
+      currentPage = response.url;
+      if (!redirectedHome) redirectedHome = currentPage;
+    },
     link: result => {
       // When a link is checked
-      const url = result.url.resolved;
-      spinner.text = cliTruncate('Checking ' + url, process.stdout.columns - 3);
+      const checkedUrl = result.url.resolved;
+      spinner.text = cliTruncate(
+        'Checking ' + checkedUrl,
+        process.stdout.columns - 3,
+      );
       // Where to put the link
       if (result.broken && result.brokenReason === 'HTTP_404') {
-        if (brokenLinks.indexOf(url) < 0) brokenLinks.push(url);
+        if (
+          options.retry &&
+          checkedUrl.startsWith(url) &&
+          !checkedUrl.startsWith(redirectedHome)
+        ) {
+          //check the retry link
+          urlChecker.enqueue(checkedUrl.replace(url, options.retry));
+          siteChecker.pause();
+        } else if (!brokenLinks.has(checkedUrl)) {
+          brokenLinks.set(checkedUrl, currentPage);
+        }
       } else {
-        if (links.indexOf(url) < 0) links.push(url);
+        if (links.indexOf(checkedUrl) < 0) {
+          if (checkedUrl.startsWith(url)) siteChecker.enqueue(checkedUrl);
+          links.push(checkedUrl);
+        }
       }
     },
     end: () => {
       // When all links have been checked
       spinner.stop();
       callback(brokenLinks, links);
-    }
+    },
   };
 
-  const siteChecker = new blc.SiteChecker(blcOptions, handlers);
+  siteChecker = new blc.HtmlUrlChecker(options, handlers);
 
   siteChecker.enqueue(url);
 };

--- a/lib/missing-content.js
+++ b/lib/missing-content.js
@@ -65,7 +65,9 @@ module.exports = (url, options, callback) => {
         }
       } else {
         if (links.indexOf(checkedUrl) < 0) {
-          if (checkedUrl.startsWith(url)) siteChecker.enqueue(checkedUrl);
+          //Add everyting if not shallow otherwise make sure new url is rooted with base url
+          if (!options.shallow) siteChecker.enqueue(checkedUrl);
+          else if (checkedUrl.startsWith(url)) siteChecker.enqueue(checkedUrl);
           links.push(checkedUrl);
         }
       }

--- a/lib/missing-content.test.js
+++ b/lib/missing-content.test.js
@@ -1,38 +1,38 @@
 const missingContent = require('./missing-content');
-const newServer = require('../test/server')
+const newServer = require('../test/server');
 
 let app;
 let site;
 
 beforeAll(() => {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     app = newServer((port, server) => {
-      site = `http://localhost:${port}`
-      
-      resolve()
-    })
-  })
-})
+      site = `http://localhost:${port}`;
+
+      resolve();
+    });
+  });
+});
 
 afterAll(() => {
-  app.close()
-})
+  app.close();
+});
 
 test('Will find the missing page', () => {
-  missingContent(site, brokenLinks => {
-    expect(brokenLinks).toContain(`${site}/nowhere.html`)
+  missingContent(site, {}, brokenLinks => {
+    expect(brokenLinks).toContain(`${site}/nowhere.html`);
   });
-})
+});
 
 test('Will not find the existing page', () => {
-  missingContent(site, brokenLinks => {
-    expect(brokenLinks).not.toContain(`${site}/index.html`)
-    expect(brokenLinks).not.toContain(`${site}/another-page.html`)
+  missingContent(site, {}, brokenLinks => {
+    expect(brokenLinks).not.toContain(`${site}/index.html`);
+    expect(brokenLinks).not.toContain(`${site}/another-page.html`);
   });
-})
+});
 
 test('Will find the missing script', () => {
-  missingContent(site, brokenLinks => {
-    expect(brokenLinks).toContain(`${site}/main.js`)
+  missingContent(site, {}, brokenLinks => {
+    expect(brokenLinks).toContain(`${site}/main.js`);
   });
-})
+});


### PR DESCRIPTION
Thank you so much for writing this great utility! This adds the retry flag, which is useful for local sites that have a different domain in prod. In our case a netlify build that redirects / to /docs/<specific site>. For links relative to the same base, such as /docs/<some other site>, we need the ability to retry. This PR adds it.

Also for sites that only want to test localhost/do a check that only involves the domain specified and no other external sites, I've added the shallow flag.

It's nice to know what page the broken link is on, so I added that in as well.

Sorry about the formatting 😬. I have prettier installed in my vim and didn't disable it each time I saved. Maybe this is a nice time to add in that configuration. You can take a peek at [this package.json](https://github.com/apollographql/apollo-link/blob/master/package.json#L87) for how to setup prettier to run before each commit.